### PR TITLE
Allow true and yes to match the correct settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "simplecov"

--- a/lib/puppet-lint/plugins/yumrepo_gpgcheck_enabled.rb
+++ b/lib/puppet-lint/plugins/yumrepo_gpgcheck_enabled.rb
@@ -20,7 +20,7 @@ PuppetLint.new_check(:yumrepo_gpgcheck_enabled) do
           setting = content_token.next_code_token.next_code_token
 
           # skip if valid. we only care about broken settings.
-          next if ['True', 1, '1', 'Yes'].include? setting.value
+          next if ['true', 1, '1', 'yes'].include? setting.value
 
           notify :warning, {
             message: 'yumrepo should enable the gpgcheck attribute',


### PR DESCRIPTION
Fixes #8

https://puppet.com/docs/puppet/5.5/types/yumrepo.html#yumrepo-attribute-gpgcheck states:

gpgcheck

(Property: This attribute represents concrete state on the target system.)

Whether to check the GPG signature on packages installed from this repository. Valid values are: false/0/no or true/1/yes. Set this to absent to remove it from the file completely.

Valid values are absent. Values can match /^(true|false|0|1|no|yes)$/.